### PR TITLE
Rename main app module

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An interactive Reflex-based dashboard that allows for exploring the impact of ex
 ```
 car_sales_dashboard/
 ├── rxconfig.py                # Reflex app configuration
-├── app.py                     # Main app module initializing the Reflex App
+├── car_sales_dashboard.py                     # Main app module initializing the Reflex App
 ├── state.py                   # Contains AppState class with state variables and handlers
 ├── components/                # UI component modules
 │   ├── __init__.py            # Package exports

--- a/car_sales_dashboard/car_sales_dashboard.py
+++ b/car_sales_dashboard/car_sales_dashboard.py
@@ -1,3 +1,4 @@
+"""Main entry point for the Car Sales Dashboard Reflex application."""
 import reflex as rx
 
 # Import the index page from the pages module

--- a/reflex.json
+++ b/reflex.json
@@ -1,4 +1,4 @@
 {
-    "app": "car_sales_dashboard.app:app",
+    "app": "car_sales_dashboard.car_sales_dashboard:app",
     "deploy_url": ""
 }


### PR DESCRIPTION
## Summary
- rename `app.py` to `car_sales_dashboard.py`
- update references in README and reflex.json
- add a module level docstring

## Testing
- `python -m py_compile car_sales_dashboard/*.py`
- `python -m car_sales_dashboard.car_sales_dashboard` *(fails: ModuleNotFoundError: No module named 'reflex')*