### PR TITLE
Add install requirements to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,4 +4,11 @@ setup(
     name="car_sales_dashboard",
     version="0.1",
     packages=find_packages(),
+    install_requires=[
+        "reflex",
+        "pandas",
+        "numpy",
+        "scikit-learn",
+        "plotly",
+    ],
 )


### PR DESCRIPTION
## Summary
- include required packages in `setup.py` so pip users get dependencies

## Testing
- `pip install -e .` *(fails: Could not connect to proxy)*